### PR TITLE
Fix crash issue on 3.1

### DIFF
--- a/demo/addons/godot-openvr/godot_openvr.gdnlib
+++ b/demo/addons/godot-openvr/godot_openvr.gdnlib
@@ -3,6 +3,7 @@
 singleton=true
 load_once=true
 symbol_prefix="godot_openvr_"
+reloadable=false
 
 [entry]
 


### PR DESCRIPTION
A new feature in 3.1 allows GDNative modules to be unloaded when focus is lost. This kills of ARVR plugins because the ARVR interface suddenly disappears and crashes Godot. This fixes the issue