### PR TITLE
Multiple overlay support

### DIFF
--- a/src/ARVRInterface.cpp
+++ b/src/ARVRInterface.cpp
@@ -7,6 +7,7 @@
 
 #include "ARVRInterface.h"
 #include "OS.hpp"
+#include "VisualServer.hpp"
 
 void godot_attach_device(arvr_data_struct *p_arvr_data, uint32_t p_device_index) {
 	if (p_device_index == vr::k_unTrackedDeviceIndex_Hmd) {
@@ -47,7 +48,7 @@ void godot_attach_device(arvr_data_struct *p_arvr_data, uint32_t p_device_index)
 					}
 				}
 			} else {
-				printf("Found tracker %i (%s)\n", p_device_index, device_name);				
+				printf("Found tracker %i (%s)\n", p_device_index, device_name);
 			}
 
 			sprintf(&device_name[strlen(device_name)], "_%i", p_device_index);
@@ -302,16 +303,22 @@ void godot_arvr_commit_for_eye(void *p_data, godot_int p_eye, godot_rid *p_rende
 			if (p_eye == 1) {
 				vr::EVROverlayError vrerr;
 
-				vrerr = vr::VROverlay()->SetOverlayTexture(arvr_data->ovr->get_overlay(), &eyeTexture);
+				for (unsigned i = 0; i < arvr_data->ovr->get_overlay_count(); i++) {
+					vr::TextureID_t texidov = godot::VisualServer::get_singleton()->texture_get_texid(godot::VisualServer::get_singleton()->viewport_get_texture(arvr_data->ovr->get_overlay(i).viewport_rid));
 
-				if (vrerr != vr::VROverlayError_None) {
-					printf("OpenVR could not set texture for overlay: %i, %s\n", vrerr, vr::VROverlay()->GetOverlayErrorNameFromEnum(vrerr));
-				}
+					if (texid == texidov) {
+						vrerr = vr::VROverlay()->SetOverlayTexture(arvr_data->ovr->get_overlay(i).handle, &eyeTexture);
 
-				vrerr = vr::VROverlay()->SetOverlayTextureBounds(arvr_data->ovr->get_overlay(), &bounds);
+						if (vrerr != vr::VROverlayError_None) {
+							printf("OpenVR could not set texture for overlay: %i, %s\n", vrerr, vr::VROverlay()->GetOverlayErrorNameFromEnum(vrerr));
+						}
 
-				if (vrerr != vr::VROverlayError_None) {
-					printf("OpenVR could not set textute bounds for overlay: %i, %s\n", vrerr, vr::VROverlay()->GetOverlayErrorNameFromEnum(vrerr));
+						vrerr = vr::VROverlay()->SetOverlayTextureBounds(arvr_data->ovr->get_overlay(i).handle, &bounds);
+
+						if (vrerr != vr::VROverlayError_None) {
+							printf("OpenVR could not set textute bounds for overlay: %i, %s\n", vrerr, vr::VROverlay()->GetOverlayErrorNameFromEnum(vrerr));
+						}
+					}
 				}
 			}
 		} else {

--- a/src/open_vr/OpenVROverlay.h
+++ b/src/open_vr/OpenVROverlay.h
@@ -5,55 +5,43 @@
 #define OPENVR_OVERLAY_H
 
 #include "godot_openvr.h"
-#include <Reference.hpp>
+#include <Viewport.hpp>
+#include <ProjectSettings.hpp>
 
 namespace godot {
 
-class OpenVROverlay : public Reference {
-	GODOT_CLASS(OpenVROverlay, Reference)
+class OpenVROverlay : public Viewport {
+	GODOT_CLASS(OpenVROverlay, Viewport)
 
 private:
 	openvr_data *ovr;
+    vr::VROverlayHandle_t overlay;
+	int overlay_id;
+
+	real_t overlay_width_in_meters;
+	bool overlay_visible;
 
 public:
 	static void _register_methods();
 
-	void _init();
-
 	OpenVROverlay();
 	~OpenVROverlay();
 
-	bool create_overlay(String p_overlay_key, String p_overlay_name);
-	bool destroy_overlay();
+    void _init();
+    void _ready();
+	void _exit_tree();
 
-	real_t get_overlay_width_in_meters() const;
+    real_t get_overlay_width_in_meters() const;
 	void set_overlay_width_in_meters(real_t p_new_size);
 
-	bool is_overlay_visible() const;
+    bool is_overlay_visible() const;
 	void set_overlay_visible(bool p_visible);
-	void show_overlay();
-	void hide_overlay();
 
-	bool track_relative_to_device(vr::TrackedDeviceIndex_t p_tracked_device_index, Transform p_transform);
+    bool track_relative_to_device(vr::TrackedDeviceIndex_t p_tracked_device_index, Transform p_transform);
 	bool overlay_position_absolute(Transform p_transform);
+
 };
 
 }
-
-/*
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-GDCALLINGCONV godot_variant openvr_overlay_is_overlay_visible(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
-GDCALLINGCONV godot_variant openvr_overlay_show_overlay(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
-GDCALLINGCONV godot_variant openvr_overlay_hide_overlay(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
-GDCALLINGCONV godot_variant openvr_overlay_track_relative_to_device(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
-GDCALLINGCONV godot_variant openvr_overlay_position_absolute(godot_object *p_instance, void *p_method_data, void *p_user_data, int p_num_args, godot_variant **p_args);
-
-#ifdef __cplusplus
-}
-#endif
-*/
 
 #endif /* !OPENVR_OVERLAY_H */

--- a/src/open_vr/openvr_data.cpp
+++ b/src/open_vr/openvr_data.cpp
@@ -153,12 +153,25 @@ void openvr_data::process() {
 	}
 }
 
-vr::VROverlayHandle_t openvr_data::get_overlay() {
-	return overlay;
+int openvr_data::get_overlay_count() {
+	return overlays.size();
 }
 
-void openvr_data::set_overlay(vr::VROverlayHandle_t p_new_value) {
-	overlay = p_new_value;
+openvr_data::overlay openvr_data::get_overlay(int p_overlay_id) {
+	return overlays[p_overlay_id];
+}
+
+int openvr_data::add_overlay(vr::VROverlayHandle_t p_new_value, godot::RID p_viewport_rid) {
+	overlay new_entry;
+	new_entry.handle = p_new_value;
+	new_entry.viewport_rid = p_viewport_rid;
+	
+	overlays.push_back(new_entry);
+	return overlays.size() - 1;
+}
+
+void openvr_data::remove_overlay(int p_overlay_id) {
+	overlays.erase(overlays.begin() + p_overlay_id);
 }
 
 openvr_data::OpenVRApplicationType openvr_data::get_application_type() {

--- a/src/open_vr/openvr_data.h
+++ b/src/open_vr/openvr_data.h
@@ -35,7 +35,14 @@ private:
 	int use_count;
 
 	vr::IVRRenderModels *render_models;
-	vr::VROverlayHandle_t overlay;
+
+	// structure to record which overlays go with which viewport
+	struct overlay {
+		vr::VROverlayHandle_t handle;
+		godot::RID viewport_rid;
+	};
+
+	std::vector<overlay> overlays;
 
 	OpenVRApplicationType application_type;
 	OpenVRTrackingUniverse tracking_universe;
@@ -82,8 +89,10 @@ public:
 	void process();
 
 	// properties
-	vr::VROverlayHandle_t get_overlay();
-	void set_overlay(vr::VROverlayHandle_t p_new_value);
+	int get_overlay_count();
+	overlay get_overlay(int p_overlay_id);
+	int add_overlay(vr::VROverlayHandle_t p_new_value, godot::RID p_viewport_rid);
+	void remove_overlay(int p_overlay_id);
 	OpenVRApplicationType get_application_type();
 	void set_application_type(OpenVRApplicationType p_new_value);
 	OpenVRTrackingUniverse get_tracking_universe();


### PR DESCRIPTION
This is multiple OpenVR overlays support!

Not much changed, but there are two breaking changes:
- create_overlay() returns an ID for the created overlay now, which
  has to be used in subsequent overlay function calls
- create_overlay() now also needs the texture ID of the Viewport to be used as texture, which you can get it in Godot through the VisualServer.

Example:
```
# Wait for everything to be ready - in case Viewport hasn't been drawn yet
yield(get_tree(), "idle_frame")
yield(get_tree(), "idle_frame")
yield(get_tree(), "idle_frame")
yield(get_tree(), "idle_frame")

# Get texture ID
var texid_overlay1 = VisualServer.texture_get_texid(VisualServer.viewport_get_texture($VRViewport1.get_viewport_rid()))
var texid_overlay2 = VisualServer.texture_get_texid(VisualServer.viewport_get_texture($VRViewport2.get_viewport_rid()))
	
OpenVROverlay = preload("res://addons/godot-openvr/OpenVROverlay.gdns").new()
var overlay_id1 = OpenVROverlay.create_overlay("identifier", "Friendly name", texid_overlay1) 
var overlay_id2 = OpenVROverlay.create_overlay("identifier2", "Friendly name2", texid_overlay2) 
```

:)