### PR TITLE
Don't rely on vr-common shader cache in asset files

### DIFF
--- a/demo/Main.tscn
+++ b/demo/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=25 format=2]
+[gd_scene load_steps=26 format=2]
 
 [ext_resource path="res://Main.gd" type="Script" id=1]
 [ext_resource path="res://assets/wahooney.itch.io/green_grid.tres" type="Material" id=2]
@@ -21,6 +21,7 @@
 [ext_resource path="res://player/Guardian.tscn" type="PackedScene" id=19]
 [ext_resource path="res://addons/godot-openvr/scenes/ovr_left_hand.tscn" type="PackedScene" id=20]
 [ext_resource path="res://addons/godot-openvr/scenes/ovr_right_hand.tscn" type="PackedScene" id=21]
+[ext_resource path="res://addons/godot-openvr/scenes/ovr_shader_cache.tscn" type="PackedScene" id=22]
 
 [sub_resource type="ArrayMesh" id=1]
 
@@ -49,6 +50,8 @@ action_json_path = "res://ovr_actions/actions.json"
 [node name="ARVRCamera" type="ARVRCamera" parent="Player"]
 
 [node name="vr_common_shader_cache" parent="Player/ARVRCamera" instance=ExtResource( 3 )]
+
+[node name="ovr_shader_cache" parent="Player/ARVRCamera" instance=ExtResource( 22 )]
 
 [node name="Left_Hand" parent="Player" instance=ExtResource( 5 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.5, 1.25, 0 )

--- a/demo/addons/godot-openvr/scenes/ovr_first_person.tscn
+++ b/demo/addons/godot-openvr/scenes/ovr_first_person.tscn
@@ -1,16 +1,10 @@
-[gd_scene load_steps=7 format=2]
+[gd_scene load_steps=5 format=2]
 
-[ext_resource path="res://addons/vr-common/misc/VR_Common_Shader_Cache.tscn" type="PackedScene" id=1]
+[ext_resource path="res://addons/godot-openvr/scenes/ovr_shader_cache.tscn" type="PackedScene" id=1]
 [ext_resource path="res://addons/godot-openvr/scenes/ovr_controller.tscn" type="PackedScene" id=2]
 [ext_resource path="res://addons/godot-openvr/scenes/ovr_main.gd" type="Script" id=3]
 
-
-[sub_resource type="PlaneMesh" id=1]
-size = Vector2( 0.001, 0.001 )
-
-[sub_resource type="SpatialMaterial" id=2]
-
-[sub_resource type="GDScript" id=3]
+[sub_resource type="GDScript" id=1]
 script/source = "extends Spatial
 
 func _physics_process(delta):
@@ -38,16 +32,11 @@ fov = 65.0
 near = 0.01
 far = 1000.01
 
-[node name="shader_cache" parent="ARVRCamera" instance=ExtResource( 1 )]
-
-[node name="Controller" type="MeshInstance" parent="ARVRCamera/shader_cache"]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -2 )
-mesh = SubResource( 1 )
-material/0 = SubResource( 2 )
+[node name="ovr_shader_cache" parent="ARVRCamera" instance=ExtResource( 1 )]
 
 [node name="HUD_Anchor" type="Spatial" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.85, 0 )
-script = SubResource( 3 )
+script = SubResource( 1 )
 
 [node name="Left_Hand" parent="." instance=ExtResource( 2 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.5, 1.25, 0 )

--- a/demo/addons/godot-openvr/scenes/ovr_shader_cache.gd
+++ b/demo/addons/godot-openvr/scenes/ovr_shader_cache.gd
@@ -1,0 +1,10 @@
+extends Spatial
+
+var countdown = 2
+
+# Called every frame. 'delta' is the elapsed time since the previous frame.
+func _process(delta):
+	countdown = countdown - 1
+	if countdown == 0:
+		visible = false
+		set_process(false)

--- a/demo/addons/godot-openvr/scenes/ovr_shader_cache.tscn
+++ b/demo/addons/godot-openvr/scenes/ovr_shader_cache.tscn
@@ -1,0 +1,16 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://addons/godot-openvr/scenes/ovr_shader_cache.gd" type="Script" id=1]
+
+[sub_resource type="PlaneMesh" id=1]
+size = Vector2( 0.001, 0.001 )
+
+[sub_resource type="SpatialMaterial" id=2]
+
+[node name="ovr_shader_cache" type="Spatial"]
+script = ExtResource( 1 )
+
+[node name="Controller" type="MeshInstance" parent="."]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, -2 )
+mesh = SubResource( 1 )
+material/0 = SubResource( 2 )


### PR DESCRIPTION
Fixes https://github.com/GodotVR/godot-openvr-asset/issues/12

We don't want the asset to be dependent on vr-common, usage of that should be optional.