### PR TITLE
Add linear to sRGB shader

### DIFF
--- a/demo/addons/godot-openvr/scenes/linear_to_srgb.shader
+++ b/demo/addons/godot-openvr/scenes/linear_to_srgb.shader
@@ -1,0 +1,11 @@
+shader_type canvas_item;
+
+void fragment() {
+	vec4 c = texture(TEXTURE, UV);
+	
+	// Linear -> sRGB
+	vec3 a = vec3(0.055);
+	c.rgb = mix((vec3(1.0) + a) * pow(c.rgb, vec3(1.0 / 2.4)) - a, 12.92 * c.rgb, lessThan(c.rgb, vec3(0.0031308)));
+	
+	COLOR = c;
+}


### PR DESCRIPTION
Will add an example scene for this as well but seeing we're now rendering to the HMD keeping our viewport in linear color space (GLES3 only) we need a way to output the preview to screen in sRGB.

The scene setup should become something like this:
```
- Main
  - ViewportVR
    - ARVROrigin
      - ARVRCamera
  - ViewportContainer
    - ViewportUI
      - TextureRect
```

The ViewportVR should become our ARVR viewport while our ViewportUI is what we render to screen. The texture of the TextureRect should be set to the viewport texture of our viewportVR.
Then the shader in this PR can be used for rendering out the texture rect.