### PR TITLE
Add debug symbols to windows debug target.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -51,7 +51,8 @@ if env['platform'] == 'windows':
 
         env.Append(CCFLAGS = ['-DWIN32', '-D_WIN32', '-D_WINDOWS', '-W3', '-GR', '-D_CRT_SECURE_NO_WARNINGS'])
         if env['target'] in ('debug', 'd'):
-            env.Append(CCFLAGS = ['-EHsc', '-D_DEBUG', '-MDd'])
+            env.Append(CCFLAGS = ['-EHsc', '-D_DEBUG', '-MDd', '-Zi', '-FS'])
+            env.Append(LINKFLAGS = ['-DEBUG:FULL'])
         else:
             env.Append(CCFLAGS = ['-O2', '-EHsc', '-DNDEBUG', '-MD'])
     # untested


### PR DESCRIPTION
Enable debug symbols in debug target, originally pull #98