### PR TITLE
Fixed OpenVRExportPlugin.gd for Godot 4.0

### DIFF
--- a/demo/addons/godot-openvr/OpenVRExportPlugin.gd
+++ b/demo/addons/godot-openvr/OpenVRExportPlugin.gd
@@ -22,7 +22,9 @@ func _export_begin(features: PackedStringArray, is_debug: bool, path: String, fl
 		dir.make_dir(export_to)
 	
 	if dir.open(export_from) == OK:
-		dir.list_dir_begin(true, true)
+		dir.include_hidden = false
+		dir.include_navigational = false
+		dir.list_dir_begin()
 		
 		var filename = dir.get_next()
 		while filename != "":


### PR DESCRIPTION
 dir.list_dir_begin(true, true) does not work with the current godot master branch.