### PR TITLE
Fix timing issue by splitting logic off to new end_frame function [Godot 4]

### DIFF
--- a/demo/addons/godot-xr-tools/functions/Function_Direct_movement.gd
+++ b/demo/addons/godot-xr-tools/functions/Function_Direct_movement.gd
@@ -37,7 +37,8 @@ enum MOVEMENT_TYPE { MOVE_AND_ROTATE, MOVE_AND_STRAFE }
 @export var drag_factor = 0.1
 
 # fly mode and strafe movement management
-@export var move_type: MOVEMENT_TYPE = MOVEMENT_TYPE.MOVE_AND_ROTATE
+# @export var move_type: MOVEMENT_TYPE = MOVEMENT_TYPE.MOVE_AND_ROTATE # temporarily disabled, enums broke
+@export var move_type: int = 0
 @export var fly_enabled = true
 @export var fly_move: String = "trigger_click"
 @export var fly_activate: String = "grip_click"
@@ -215,13 +216,13 @@ func _physics_process(delta):
 			# Apply our drag
 			velocity *= (1.0 - drag_factor)
 
-			if move_type == MOVEMENT_TYPE.MOVE_AND_ROTATE:
+			if move_type == 0: ## 0 = MOVEMENT_TYPE.MOVE_AND_ROTATE
 				if (abs(forwards_backwards) > 0.1 and tail.is_colliding()):
 					var dir = camera_transform.basis.z
 					dir.y = 0.0
 					velocity = dir.normalized() * -forwards_backwards * max_speed * XRServer.world_scale
 					#velocity = velocity.linear_interpolate(dir, delta * 100.0)
-			elif move_type == MOVEMENT_TYPE.MOVE_AND_STRAFE:
+			elif move_type == 1: ## 1 = MOVEMENT_TYPE.MOVE_AND_STRAFE
 				if ((abs(forwards_backwards) > 0.1 ||  abs(left_right) > 0.1) and tail.is_colliding()):
 					var dir_forward = camera_transform.basis.z
 					dir_forward.y = 0.0

--- a/demo/addons/godot-xr-tools/functions/Function_Teleport.gd
+++ b/demo/addons/godot-xr-tools/functions/Function_Teleport.gd
@@ -214,11 +214,11 @@ func _physics_process(delta):
 						var start_pos = target_global_origin + (Vector3.UP * 0.5 * player_height)
 						var end_pos = target_global_origin - (Vector3.UP * 1.1 * player_height)
 						
-						var ray_query : PhysicsRayQueryParameters3D
-						ray_query.from = start_pos
-						ray_query.to = end_pos
-						ray_query.collision_mask = collision_mask
-						var intersects = state.intersect_ray(ray_query)
+						var params : PhysicsRayQueryParameters3D
+						params.from = start_pos
+						params.to = end_pos
+						params.collision_mask = collision_mask
+						var intersects = state.intersect_ray(params)
 						if intersects.is_empty():
 							is_on_floor = false
 						else:

--- a/demo/player/ButtonStates.gd
+++ b/demo/player/ButtonStates.gd
@@ -22,11 +22,11 @@ func _process(delta):
 
 		var trigger = controller.get_value("trigger_value")
 		$VBoxContainer/Trigger/Value.value = 100.0 * trigger
-		$VBoxContainer/Trigger/Pressed.pressed = controller.is_button_pressed("trigger_click")
+		$VBoxContainer/Trigger/Pressed.button_pressed = controller.is_button_pressed("trigger_click")
 
 		var grip = controller.get_value("grip_value")
 		$VBoxContainer/Grip/Value.value = 100.0 * grip
-		$VBoxContainer/Grip/Pressed.pressed = controller.is_button_pressed("grip_click")
-		$VBoxContainer/AX/Pressed.pressed = controller.is_button_pressed("ax")
-		$VBoxContainer/BY/Pressed.pressed = controller.is_button_pressed("by")
+		$VBoxContainer/Grip/Pressed.button_pressed = controller.is_button_pressed("grip_click")
+		$VBoxContainer/AX/Pressed.button_pressed = controller.is_button_pressed("ax")
+		$VBoxContainer/BY/Pressed.button_pressed = controller.is_button_pressed("by")
 		

--- a/src/open_vr/openvr_data.h
+++ b/src/open_vr/openvr_data.h
@@ -107,6 +107,8 @@ private:
 	// tracked devices
 	Ref<XRPositionalTracker> head_tracker;
 	godot::Transform3D hmd_transform;
+	godot::Vector3 hmd_linear_velocity;
+	godot::Vector3 hmd_angular_velocity;
 
 	struct tracked_device {
 		Ref<XRPositionalTracker> tracker;
@@ -122,6 +124,7 @@ private:
 	void attach_device(uint32_t p_device_index);
 	void detach_device(uint32_t p_device_index);
 	void process_device_actions(tracked_device *p_device, uint64_t p_msec);
+	XRPose::TrackingConfidence confidence_from_tracking_result(vr::ETrackingResult p_tracking_result);
 
 	////////////////////////////////////////////////////////////////
 	// meshes (should see about moving this into a separate class)

--- a/src/xr_interface_openvr.h
+++ b/src/xr_interface_openvr.h
@@ -25,7 +25,7 @@ private:
 	uint32_t height = 0;
 
 	OS::VideoDriver video_driver = OS::VIDEO_DRIVER_VULKAN;
-	int texture_id = 0;
+	RID texture_rid;
 
 public:
 	// Properties
@@ -66,9 +66,10 @@ public:
 	virtual Transform3D _get_transform_for_view(int64_t p_view, const Transform3D &p_cam_transform) override;
 	virtual PackedFloat64Array _get_projection_for_view(int64_t p_view, double p_aspect, double p_z_near, double p_z_far) override;
 
-	virtual void _commit_views(const RID &p_render_target, const Rect2 &p_screen_rect) override;
-
 	virtual void _process() override;
+	virtual void _post_draw_viewport(const RID &render_target, const Rect2 &screen_rect) override;
+	virtual void _end_frame() override;
+
 	virtual void _notification(int64_t what) override;
 
 	XRInterfaceOpenVR();


### PR DESCRIPTION
This PR fixes timing issues related to Godot 4 (and a few cleanup things)

To test:
- Build Godot with master from today or later
- Build the OpenVR plugin as per usual

voila.