### PR TITLE
Make proper use of WaitGetPoses

### DIFF
--- a/demo/Main.tscn
+++ b/demo/Main.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=27 format=2]
+[gd_scene load_steps=28 format=2]
 
 [ext_resource path="res://Main.gd" type="Script" id=1]
 [ext_resource path="res://assets/wahooney.itch.io/green_grid.tres" type="Material" id=2]
@@ -23,6 +23,7 @@
 [ext_resource path="res://addons/godot-openvr/scenes/ovr_right_hand.tscn" type="PackedScene" id=21]
 [ext_resource path="res://addons/godot-openvr/scenes/ovr_shader_cache.tscn" type="PackedScene" id=22]
 [ext_resource path="res://misc/Cup.tscn" type="PackedScene" id=23]
+[ext_resource path="res://addons/godot-openvr/scenes/framecounter_in_3d.tscn" type="PackedScene" id=24]
 
 [sub_resource type="ArrayMesh" id=1]
 
@@ -46,13 +47,16 @@ directional_shadow_max_distance = 50.0
 
 [node name="Player" type="ARVROrigin" parent="."]
 script = ExtResource( 13 )
-action_json_path = "res://ovr_actions/actions.json"
 
 [node name="ARVRCamera" type="ARVRCamera" parent="Player"]
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1.8, 0 )
 
 [node name="vr_common_shader_cache" parent="Player/ARVRCamera" instance=ExtResource( 3 )]
 
 [node name="ovr_shader_cache" parent="Player/ARVRCamera" instance=ExtResource( 22 )]
+
+[node name="FPS" parent="Player/ARVRCamera" instance=ExtResource( 24 )]
+transform = Transform( 0.923552, -0.383473, 0, -0.0754683, -0.181757, -0.980443, 0.375974, 0.90549, -0.196802, 0.331706, 0.188307, -0.889295 )
 
 [node name="Left_Hand" parent="Player" instance=ExtResource( 5 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.5, 1.25, 0 )
@@ -82,7 +86,6 @@ canFly = false
 transform = Transform( 0.707107, 2.98023e-08, -0.707107, 0.5, 0.707107, 0.5, 0.5, -0.707107, 0.5, 0.15, 0.1, 0 )
 screen_size = Vector2( 0.2, 0.2 )
 viewport_size = Vector2( 200, 200 )
-transparent = true
 scene = ExtResource( 11 )
 collision_layer = 0
 
@@ -156,5 +159,6 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -3, 2, -4 )
 
 [node name="Box03" parent="Misc" instance=ExtResource( 8 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -3, 3, -4 )
+
 [connection signal="action_pressed" from="Player/Right_Hand" to="." method="_on_Right_Hand_action_pressed"]
 [connection signal="pressed" from="Player/Guardian/Toggle" to="." method="_on_Toggle_Guardian_pressed"]

--- a/demo/addons/godot-openvr/scenes/framecounter_in_3d.tscn
+++ b/demo/addons/godot-openvr/scenes/framecounter_in_3d.tscn
@@ -16,7 +16,7 @@ void vertex() {
 }
 
 void fragment() {
-	vec4 col = texture(viewport_texture, vec2(1.0 - UV.x, UV.y));
+	vec4 col = texture(viewport_texture, vec2(UV.x, 1.0 - UV.y));
 	ALBEDO = col.rgb;
 	ALPHA = col.a;
 }

--- a/src/ARVRInterface.cpp
+++ b/src/ARVRInterface.cpp
@@ -138,7 +138,7 @@ godot_transform godot_arvr_get_transform_for_eye(void *p_data, godot_int p_eye, 
 	godot_real world_scale = godot::arvr_api->godot_arvr_get_worldscale();
 
 	if (p_eye == 0) {
-		// we want a monoscopic transform.. shouldn't really apply here
+		// we want a monoscopic transform.. used when updating our camera node position (in this case we'll be using next frames position)
 		godot::api->godot_transform_new_identity(&transform_for_eye);
 	} else if (arvr_data->ovr != NULL) {
 		arvr_data->ovr->get_eye_to_head_transform(&transform_for_eye, p_eye, world_scale);
@@ -158,7 +158,7 @@ godot_transform godot_arvr_get_transform_for_eye(void *p_data, godot_int p_eye, 
 	// :)
 	ret = *p_cam_transform;
 	ret = godot::api->godot_transform_operator_multiply(&ret, &reference_frame);
-	ret = godot::api->godot_transform_operator_multiply(&ret, arvr_data->ovr->get_hmd_transform());
+	ret = godot::api->godot_transform_operator_multiply(&ret, arvr_data->ovr->get_hmd_transform(p_eye == 0));
 	ret = godot::api->godot_transform_operator_multiply(&ret, &transform_for_eye);
 
 	return ret;

--- a/src/open_vr/openvr_data.h
+++ b/src/open_vr/openvr_data.h
@@ -121,6 +121,7 @@ private:
 	void process_device_actions(tracked_device *p_device, uint64_t p_msec);
 
 	godot_transform hmd_transform;
+	godot_transform hmd_transform_next;
 
 	// custom actions
 	struct custom_action {
@@ -190,7 +191,7 @@ public:
 	// interact with tracking info
 	godot::String get_default_action_set() const;
 	void set_default_action_set(const godot::String p_name);
-	const godot_transform *get_hmd_transform() const;
+	const godot_transform *get_hmd_transform(bool p_next_frame = false) const;
 	int register_action_set(const godot::String p_action_set);
 	void set_active_action_set(const godot::String p_action_set);
 	void toggle_action_set_active(const godot::String p_action_set, bool p_is_active);


### PR DESCRIPTION
The function `WaitGetPoses` returns two sets of tracking data. Tracking data for the current frame, and predictive tracking data for the next frame.

We call, as we should, `WaitGetPoses` as close to when we render as possible, however we do not update the positions of our node until we process the next frame.

This PR ensures that our head position for rendering uses the most up to date tracking data as we currently do, but we now use the predictive tracking data for the next frame when positioning nodes.

Now Godot 3 still processes this data within `_process` so we do not have the nodes in the correct position until after that nodes `_process` has run, but this can be dealt with. This is something that has been improved in Godot 4.

But with this fix it should ensure that controller positions no longer seem to be a frame behind and more importantly, that nodes childed to the ARVRCamera will appear in the correct position. 