### PR TITLE
Read our own action manifest to configure inputs

### DIFF
--- a/demo/addons/godot-openvr/actions/actions.json
+++ b/demo/addons/godot-openvr/actions/actions.json
@@ -1,5 +1,5 @@
 {
-	"action_set" : [
+	"action_sets" : [
 		{
 			"name" : "/actions/godot",
 			"usage" : "leftright"
@@ -7,32 +7,32 @@
 	],
 	"actions" : [
 		{
-			"name": "/actions/godot/in/aim_pose",
+			"name": "/actions/godot/in/aim",
 			"requirement" : "mandatory",
 			"type": "pose"
 		},
 		{
-			"name": "/actions/godot/in/grip_pose",
+			"name": "/actions/godot/in/grip",
 			"requirement" : "mandatory",
 			"type": "pose"
 		},
 		{
-			"name" : "/actions/godot/in/trigger",
+			"name" : "/actions/godot/in/trigger_click",
 			"requirement" : "mandatory",
 			"type" : "boolean"
 		},
 		{
-			"name" : "/actions/godot/in/analog_trigger",
+			"name" : "/actions/godot/in/trigger_value",
 			"requirement" : "suggested",
 			"type" : "vector1"
 		},
 		{
-			"name" : "/actions/godot/in/grip",
+			"name" : "/actions/godot/in/grip_click",
 			"requirement" : "suggested",
 			"type" : "boolean"
 		},
 		{
-			"name" : "/actions/godot/in/analog_grip",
+			"name" : "/actions/godot/in/grip_value",
 			"requirement" : "suggested",
 			"type" : "vector1"
 		},
@@ -57,12 +57,12 @@
 			"type" : "boolean"
 		},
 		{
-			"name" : "/actions/godot/in/button_ax",
+			"name" : "/actions/godot/in/ax",
 			"requirement" : "optional",
 			"type" : "boolean"
 		},
 		{
-			"name" : "/actions/godot/in/button_by",
+			"name" : "/actions/godot/in/by",
 			"requirement" : "optional",
 			"type" : "boolean"
 		},

--- a/src/open_vr/openvr_data.h
+++ b/src/open_vr/openvr_data.h
@@ -208,6 +208,7 @@ public:
 	////////////////////////////////////////////////////////////////
 	// action set
 
+	bool set_action_manifest_path(const godot::String p_path);
 	godot::String get_default_action_set() const;
 	void set_default_action_set(const godot::String p_name);
 	int register_action_set(const godot::String p_action_set);

--- a/src/xr_interface_openvr.cpp
+++ b/src/xr_interface_openvr.cpp
@@ -24,6 +24,7 @@ void XRInterfaceOpenVR::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_default_action_set"), &XRInterfaceOpenVR::set_default_action_set);
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "default_action_set"), "set_default_action_set", "get_default_action_set");
 
+	ClassDB::bind_method(D_METHOD("set_action_manifest_path"), &XRInterfaceOpenVR::set_action_manifest_path);
 	ClassDB::bind_method(D_METHOD("register_action_set"), &XRInterfaceOpenVR::register_action_set);
 	ClassDB::bind_method(D_METHOD("set_active_action_set"), &XRInterfaceOpenVR::set_active_action_set);
 	ClassDB::bind_method(D_METHOD("toggle_action_set_active"), &XRInterfaceOpenVR::toggle_action_set_active);
@@ -61,6 +62,14 @@ void XRInterfaceOpenVR::set_tracking_universe(int p_universe) {
 	if (ovr != nullptr) {
 		ovr->set_tracking_universe((openvr_data::OpenVRTrackingUniverse)p_universe);
 	}
+}
+
+bool XRInterfaceOpenVR::set_action_manifest_path(const String p_path) {
+	if (ovr == nullptr) {
+		return false;
+	}
+
+	return ovr->set_action_manifest_path(p_path);
 }
 
 String XRInterfaceOpenVR::get_default_action_set() const {

--- a/src/xr_interface_openvr.h
+++ b/src/xr_interface_openvr.h
@@ -37,6 +37,7 @@ public:
 	String get_default_action_set() const;
 	void set_default_action_set(const String p_name);
 
+	bool set_action_manifest_path(const String p_path);
 	void register_action_set(const String p_action_set);
 	void set_active_action_set(const String p_action_set);
 	void toggle_action_set_active(const String p_action_set, const bool p_is_active);


### PR DESCRIPTION
For my application, I am dynamically generating action sets at startup. Since there was already a TODO about looking at the JSON to set up inputs internally, I did that. This also required fixing the other TODO about renaming actions so they match the Godot button names.

I also allow starting up without an action set present, so that it can be set at the application's leisure. As long as a game doesn't have an action manifest configured for publishing via the Steam backend, it is free to call `SetActionManifestPath` as many times as it wants and at any point during application lifecycle. At the moment a blank action set is created immediately at startup, but this is to make the inspector not explode when looking at the property. I want to remove this eventually.

This _might_ fix #132. I'm using input in a weird way for my app so I haven't tried mapping actual analog data through to a game as godot input.