### PR TITLE
Update CI to use modern Ubuntu image

### DIFF
--- a/.github/workflows/build-on-push.yml
+++ b/.github/workflows/build-on-push.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: true
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             platform: linux
           - os: windows-latest
             platform: windows
@@ -68,7 +68,7 @@ jobs:
   # This job collects the build output and assembles the final asset (artifact)
   asset:
     name: Assemble release bundle
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: build
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
 

--- a/.github/workflows/static_checks.yml
+++ b/.github/workflows/static_checks.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   static-checks:
     name: Formatting (clang-format, file format)
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixes: https://github.com/GodotVR/godot_openvr/issues/164

Also updates to Godot Engine 4.4 godot-cpp.