### PR TITLE
Expose VREvents as Godot signals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,3 @@ Thumbs.db
 *.idb
 *.ilk
 *.dll
-demo/addons/godot-xr-tools

--- a/README.md
+++ b/README.md
@@ -78,8 +78,6 @@ See the Windows platform-specific notes below for further info about mingw and p
 The finished GDExtension must be shipped with Valve's `openvr_api.dll` (Windows) or `libopenvr_api.so` (Linux). This is handled automatically by the build system whenever possible. The expected res:// paths of the library can be found in godot\_openvr.gdextension.
 
 ## Running the demo
-To use the demo you will additionally need to install the godot-xr-tools addon, which is available in the asset library within the editor. For alternative installation methods, see [the documentation](https://godotvr.github.io/godot-xr-tools/docs/installation/).
-After installing, you will need to make sure it is enabled and then restart the editor.
 
 If you are building yourself, the demo should now be runnable. If you want to test it out without building, you can download the package from the latest Github actions build, unzip it, and replace the addons/godot-openvr directory with the one from the zip. Note that the debug build is not currently included in the package.
 

--- a/demo/Main.tscn
+++ b/demo/Main.tscn
@@ -54,6 +54,13 @@ transform = Transform3D(0.965182, 0.11344, 0.235702, -0.0501897, 0.964641, -0.25
 pixel_size = 0.003
 text = "FPS: 00"
 
+[node name="Events" type="Label3D" parent="OVRFirstPerson/HUD_Anchor" index="1"]
+transform = Transform3D(0.965182, 0.11344, 0.235702, -0.0501897, 0.964641, -0.258746, -0.25672, 0.237907, 0.936747, -0.322, 0.272, -0.967)
+pixel_size = 0.003
+text = "Events appear here"
+font_size = 16
+vertical_alignment = 0
+
 [node name="TestCube" type="MeshInstance3D" parent="OVRFirstPerson/Left_Hand" index="1"]
 mesh = SubResource("BoxMesh_jxy6n")
 skeleton = NodePath("../../Right_Hand")

--- a/demo/addons/godot-openvr/openvr_autoloader.gd
+++ b/demo/addons/godot-openvr/openvr_autoloader.gd
@@ -1,5 +1,5 @@
 @tool
-extends Node
+extends OpenVREventHandler
 
 var _xr_interface_openvr : XRInterfaceOpenVR
 

--- a/demo/player/HUD_Anchor.gd
+++ b/demo/player/HUD_Anchor.gd
@@ -1,5 +1,19 @@
 extends "res://addons/godot-openvr/scenes/ovr_hud_anchor.gd"
 
+
+func _ready() -> void:
+	# A sampling of VREvents which are exposed as signals:
+	OpenVRInterface.DashboardActivated.connect(_handle_vrevent.bind("Dashboard open"))
+	OpenVRInterface.DashboardDeactivated.connect(_handle_vrevent.bind("Dashboard closed"))
+	OpenVRInterface.TrackedDeviceActivated.connect(_handle_vrevent.bind("Found device"))
+	OpenVRInterface.TrackedDeviceDeactivated.connect(_handle_vrevent.bind("Lost device"))
+
 func _process(_delta):
 	var fps = Performance.get_monitor(Performance.TIME_FPS)
 	$FPS.text = "FPS: " + str(fps)
+
+
+func _handle_vrevent(_age, tracker, _data, message=""):
+	var lines: Array = $Events.text.split("\n")
+	lines.push_front(message + (": " + tracker.name if tracker else ""))
+	$Events.text = "\n".join(lines.slice(0, 2))

--- a/demo/project.godot
+++ b/demo/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="OpenVR demo"
 run/main_scene="res://Main.tscn"
-config/features=PackedStringArray("4.2")
+config/features=PackedStringArray("4.3")
 config/icon="res://icon.png"
 
 [autoload]

--- a/src/open_vr/openvr_data.h
+++ b/src/open_vr/openvr_data.h
@@ -23,10 +23,14 @@
 #include <godot_cpp/classes/xr_positional_tracker.hpp>
 #include <godot_cpp/classes/xr_server.hpp>
 #include <godot_cpp/godot.hpp>
+#include <godot_cpp/templates/vmap.hpp>
 
 #include <vector>
 
 namespace godot {
+class OpenVREventHandler; // Cyclic reference...
+class OpenVROverlayContainer;
+
 class openvr_data {
 public:
 	// enums
@@ -42,9 +46,51 @@ public:
 		RAW
 	};
 
+	enum OpenVREventDataType { // Derived from the VREvent_Data_t union.
+		None, // Documented to contain no data.
+		Unknown = None, // Undocumented and not yet determined. Please fix these entries if you can!
+
+		// Reserved, // Unused, here for completeness.
+		Controller,
+		Mouse,
+		Scroll,
+		Process,
+		Notification,
+		Overlay,
+		Status,
+		Keyboard,
+		Ipd,
+		Chaperone,
+		PerformanceTest,
+		TouchPadMove,
+		SeatedZeroPoseReset,
+		Screenshot,
+		ScreenshotProgress,
+		ApplicationLaunch,
+		EditingCameraSurface,
+		MessageOverlay,
+		Property,
+		HapticVibration,
+		WebConsole,
+		InputBindingLoad,
+		InputActionManifestLoad,
+		SpatialAnchor,
+		ProgressUpdate,
+		ShowUI,
+		ShowDevTools,
+		HDCPError,
+		AudioVolumeControl,
+		AudioMuteControl,
+	};
+
+	struct vr_event {
+		OpenVREventDataType data_type;
+		StringName signal_name;
+	};
+
 	struct overlay {
 		vr::VROverlayHandle_t handle;
-		ObjectID container_instance_id;
+		OpenVROverlayContainer *container;
 	};
 
 private:
@@ -58,6 +104,9 @@ private:
 
 	OpenVRApplicationType application_type;
 	OpenVRTrackingUniverse tracking_universe;
+
+	OpenVREventHandler *vrevent_handler;
+	static VMap<uint32_t, vr_event> event_signals;
 
 	vr::IVRChaperone *chaperone;
 	bool play_area_is_dirty;
@@ -161,6 +210,8 @@ private:
 	void load_texture(TextureType p_type, vr::TextureID_t p_texture_id, godot::Ref<godot::StandardMaterial3D> p_material);
 	bool _load_texture(texture_material *p_texture);
 
+	void _handle_event(Node *source, vr::VREvent_t event);
+
 public:
 	vr::IVRSystem *hmd; // make this private?
 
@@ -170,6 +221,8 @@ public:
 
 	static openvr_data *retain_singleton();
 	void release();
+
+	static void register_event_signal(uint32_t p_event_id, OpenVREventDataType p_type, String p_signal_name);
 
 	////////////////////////////////////////////////////////////////
 	// interact with openvr
@@ -183,6 +236,9 @@ public:
 
 	void pre_render_update();
 
+	void set_vrevent_handler(OpenVREventHandler *handler);
+	void remove_vrevent_handler(OpenVREventHandler *handler);
+
 	// interact with tracking info
 	const godot::Transform3D get_hmd_transform() const;
 	vr::TrackedDeviceIndex_t get_tracked_device_index(Ref<XRPositionalTracker> p_tracker);
@@ -191,7 +247,7 @@ public:
 	// overlay
 	int get_overlay_count();
 	overlay *get_overlay(int p_overlay_id);
-	int add_overlay(vr::VROverlayHandle_t p_new_value, ObjectID p_container_instance_id);
+	int add_overlay(vr::VROverlayHandle_t p_new_value, OpenVROverlayContainer *container);
 	void remove_overlay(int p_overlay_id);
 
 	////////////////////////////////////////////////////////////////
@@ -241,5 +297,7 @@ public:
 	void transform_from_bone(Transform3D &p_transform, const vr::VRBoneTransform_t *p_bone_transform);
 };
 } // namespace godot
+
+VARIANT_ENUM_CAST(openvr_data::OpenVREventDataType);
 
 #endif /* !OPENVR_DATA_H */

--- a/src/open_vr/openvr_event_handler.cpp
+++ b/src/open_vr/openvr_event_handler.cpp
@@ -1,0 +1,310 @@
+#pragma GCC diagnostic ignored "-Wunknown-pragmas"
+#pragma GCC optimize("no-var-tracking") // GCC's variable assignment tracking chokes on the huge number of structs in _bind_methods.
+
+#include "openvr_event_handler.h"
+#include "openvr_event_signals.h"
+#include <godot_cpp/variant/utility_functions.hpp>
+
+using namespace godot;
+
+void OpenVREventHandler::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("register_event_signal", "event_id", "type", "signal_name"), &OpenVREventHandler::register_event_signal);
+
+	// Expose the event type constants for use in GDScript land with `register_event_signal`.
+	BIND_ENUM_CONSTANT(openvr_data::None);
+	BIND_ENUM_CONSTANT(openvr_data::Controller);
+	BIND_ENUM_CONSTANT(openvr_data::Mouse);
+	BIND_ENUM_CONSTANT(openvr_data::Scroll);
+	BIND_ENUM_CONSTANT(openvr_data::Process);
+	BIND_ENUM_CONSTANT(openvr_data::Notification);
+	BIND_ENUM_CONSTANT(openvr_data::Overlay);
+	BIND_ENUM_CONSTANT(openvr_data::Status);
+	BIND_ENUM_CONSTANT(openvr_data::Keyboard);
+	BIND_ENUM_CONSTANT(openvr_data::Ipd);
+	BIND_ENUM_CONSTANT(openvr_data::Chaperone);
+	BIND_ENUM_CONSTANT(openvr_data::PerformanceTest);
+	BIND_ENUM_CONSTANT(openvr_data::TouchPadMove);
+	BIND_ENUM_CONSTANT(openvr_data::SeatedZeroPoseReset);
+	BIND_ENUM_CONSTANT(openvr_data::Screenshot);
+	BIND_ENUM_CONSTANT(openvr_data::ScreenshotProgress);
+	BIND_ENUM_CONSTANT(openvr_data::ApplicationLaunch);
+	BIND_ENUM_CONSTANT(openvr_data::EditingCameraSurface);
+	BIND_ENUM_CONSTANT(openvr_data::MessageOverlay);
+	BIND_ENUM_CONSTANT(openvr_data::Property);
+	BIND_ENUM_CONSTANT(openvr_data::HapticVibration);
+	BIND_ENUM_CONSTANT(openvr_data::WebConsole);
+	BIND_ENUM_CONSTANT(openvr_data::InputBindingLoad);
+	BIND_ENUM_CONSTANT(openvr_data::InputActionManifestLoad);
+	BIND_ENUM_CONSTANT(openvr_data::SpatialAnchor);
+	BIND_ENUM_CONSTANT(openvr_data::ProgressUpdate);
+	BIND_ENUM_CONSTANT(openvr_data::ShowUI);
+	BIND_ENUM_CONSTANT(openvr_data::ShowDevTools);
+	BIND_ENUM_CONSTANT(openvr_data::HDCPError);
+	BIND_ENUM_CONSTANT(openvr_data::AudioVolumeControl);
+	BIND_ENUM_CONSTANT(openvr_data::AudioMuteControl);
+
+	// The EVREvent "documentation" is incomplete: only a handful of the events have a comment describing which VREvent_Data_t
+	// is attached to them. Here, we use `Unknown` for the ones that haven't yet been reverse engineered. `None` means it is
+	// known to actually not include any data.
+	//
+	// Any entries which are determined via reverse engineering (or guessing) should have a comment indicating as much, just
+	// to set the appropriate level of skepticism if bugs are traced back here.
+	//
+	// The last argument of the macro is provided to track the confidence in an entry being correct:
+	// - "none" means it's a mystery, should appear with Unknown.
+	// - "guess" means makes sense but hasn't been tested
+	// - "tested" means it was a guess but has been tested and seems to return the correct info
+	// - "header" means openvr.h says so
+	// - "comment" means see the comment for details
+	//
+	// These values are only for human reference. Feel free to add another if it's more nuanced.
+	//
+	// The whitespace below matches Valve's so this is a little easier to skim alongside openvr.h. Overlay events are left
+	// here as comments for completeness, but actually exist in openvr_overlay_container.cpp. Other events that are sent only
+	// to the compositor, etc, are also preserved as comments for completeness.
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_TrackedDeviceActivated, openvr_data::None, guess); // Guessing None because the trackedDeviceIndex in the event would identify which one.
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_TrackedDeviceDeactivated, openvr_data::None, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_TrackedDeviceUpdated, openvr_data::None, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_TrackedDeviceUserInteractionStarted, openvr_data::None, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_TrackedDeviceUserInteractionEnded, openvr_data::None, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_IpdChanged, openvr_data::Ipd, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_EnterStandbyMode, openvr_data::None, guess); // Probably no info needed.
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_LeaveStandbyMode, openvr_data::None, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_TrackedDeviceRoleChanged, openvr_data::None, comment); // https://github.com/ValveSoftware/openvr/issues/853: No data OR trackedDeviceIndex, re-query all devices.
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_WatchdogWakeUpRequested, openvr_data::None, guess); // Probably no info needed.
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_LensDistortionChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_PropertyChanged, openvr_data::Property, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_WirelessDisconnect, openvr_data::None, guess); // trackedDeviceIndex again
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_WirelessReconnect, openvr_data::None, guess);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ButtonPress, openvr_data::Controller, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ButtonUnpress, openvr_data::Controller, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ButtonTouch, openvr_data::Controller, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ButtonUntouch, openvr_data::Controller, header);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Modal_Cancel, openvr_data::Unknown, none);
+
+	// vr::EVREventType::VREvent_MouseMove
+	// vr::EVREventType::VREvent_MouseButtonDown
+	// vr::EVREventType::VREvent_MouseButtonUp
+	// vr::EVREventType::VREvent_FocusEnter
+	// vr::EVREventType::VREvent_FocusLeave
+	// vr::EVREventType::VREvent_ScrollDiscrete
+	// vr::EVREventType::VREvent_TouchPadMove
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_OverlayFocusChanged, openvr_data::Overlay, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ReloadOverlays, openvr_data::Unknown, none);
+	// vr::EVREventType::VREvent_ScrollSmooth
+	// vr::EVREventType::VREvent_LockMousePosition
+	// vr::EVREventType::VREvent_UnlockMousePosition
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_InputFocusCaptured, openvr_data::Process, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_InputFocusReleased, openvr_data::Process, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_SceneApplicationChanged, openvr_data::Process, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_InputFocusChanged, openvr_data::Process, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_SceneApplicationUsingWrongGraphicsAdapter, openvr_data::Process, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ActionBindingReloaded, openvr_data::Process, header);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_HideRenderModels, openvr_data::None, guess); // No more info seems needed
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ShowRenderModels, openvr_data::None, guess);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_SceneApplicationStateChanged, openvr_data::None, header);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_SceneAppPipeDisconnected, openvr_data::Process, header);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ConsoleOpened, openvr_data::WebConsole, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ConsoleClosed, openvr_data::WebConsole, guess);
+
+	// vr::EVREventType::VREvent_OverlayShown
+	// vr::EVREventType::VREvent_OverlayHidden
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_DashboardActivated, openvr_data::None, tested);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_DashboardDeactivated, openvr_data::None, tested);
+	// vr::EVREventType::VREvent_DashboardRequested
+	// vr::EVREventType::VREvent_ResetDashboard
+	// vr::EVREventType::VREvent_ImageLoaded
+	// vr::EVREventType::VREvent_ShowKeyboard
+	// vr::EVREventType::VREvent_HideKeyboard
+	// vr::EVREventType::VREvent_OverlayGamepadFocusGained
+	// vr::EVREventType::VREvent_OverlayGamepadFocusLost
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_OverlaySharedTextureChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ScreenshotTriggered, openvr_data::Unknown, none);
+	// vr::EVREventType::VREvent_ImageFailed
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_DashboardOverlayCreated, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_SwitchGamepadFocus, openvr_data::Unknown, none);
+
+	// vr::EVREventType::VREvent_RequestScreenshot
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ScreenshotTaken, openvr_data::Screenshot, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ScreenshotFailed, openvr_data::Screenshot, guess);
+	// vr::EVREventType::VREvent_SubmitScreenshotToDashboard
+	// vr::EVREventType::VREvent_ScreenshotProgressToDashboard
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_PrimaryDashboardDeviceChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_RoomViewShown, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_RoomViewHidden, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ShowUI, openvr_data::ShowUI, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ShowDevTools, openvr_data::ShowDevTools, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_DesktopViewUpdating, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_DesktopViewReady, openvr_data::Unknown, none);
+
+	// vr::EVREventType::VREvent_StartDashboard
+	// vr::EVREventType::VREvent_ElevatePrism
+
+	// vr::EVREventType::VREvent_OverlayClosed
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_DashboardThumbChanged, openvr_data::Overlay, tested);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_DesktopMightBeVisible, openvr_data::None, guess); // A global state
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_DesktopMightBeHidden, openvr_data::None, guess);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_MutualSteamCapabilitiesChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_OverlayCreated, openvr_data::Overlay, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_OverlayDestroyed, openvr_data::Overlay, header);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Notification_Shown, openvr_data::Notification, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Notification_Hidden, openvr_data::Notification, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Notification_BeginInteraction, openvr_data::Notification, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Notification_Destroyed, openvr_data::Notification, guess);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Quit, openvr_data::Process, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ProcessQuit, openvr_data::Process, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_QuitAcknowledged, openvr_data::Process, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_DriverRequestedQuit, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_RestartRequested, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_InvalidateSwapTextureSets, openvr_data::Unknown, none);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ChaperoneDataHasChanged, openvr_data::Chaperone, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ChaperoneUniverseHasChanged, openvr_data::Chaperone, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ChaperoneTempDataHasChanged, openvr_data::Chaperone, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ChaperoneSettingsHaveChanged, openvr_data::Chaperone, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_SeatedZeroPoseReset, openvr_data::SeatedZeroPoseReset, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ChaperoneFlushCache, openvr_data::Chaperone, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ChaperoneRoomSetupStarting, openvr_data::Chaperone, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ChaperoneRoomSetupFinished, openvr_data::Chaperone, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_StandingZeroPoseReset, openvr_data::Unknown, none);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_AudioSettingsHaveChanged, openvr_data::Unknown, none);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_BackgroundSettingHasChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_CameraSettingsHaveChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ReprojectionSettingHasChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ModelSkinSettingsHaveChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_EnvironmentSettingsHaveChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_PowerSettingsHaveChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_EnableHomeAppSettingsHaveChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_SteamVRSectionSettingChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_LighthouseSectionSettingChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_NullSectionSettingChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_UserInterfaceSectionSettingChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_NotificationsSectionSettingChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_KeyboardSectionSettingChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_PerfSectionSettingChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_DashboardSectionSettingChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_WebInterfaceSectionSettingChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_TrackersSectionSettingChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_LastKnownSectionSettingChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_DismissedWarningsSectionSettingChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_GpuSpeedSectionSettingChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_WindowsMRSectionSettingChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_OtherSectionSettingChanged, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_AnyDriverSettingsChanged, openvr_data::Unknown, none);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_StatusUpdate, openvr_data::Status, guess);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_WebInterface_InstallDriverCompleted, openvr_data::Unknown, none);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_MCImageUpdated, openvr_data::Unknown, none);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_FirmwareUpdateStarted, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_FirmwareUpdateFinished, openvr_data::Unknown, none);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_KeyboardClosed, openvr_data::None, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_KeyboardCharInput, openvr_data::Keyboard, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_KeyboardDone, openvr_data::None, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_KeyboardOpened_Global, openvr_data::Keyboard, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_KeyboardClosed_Global, openvr_data::Keyboard, header);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ApplicationListUpdated, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ApplicationMimeTypeLoad, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ProcessConnected, openvr_data::Process, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ProcessDisconnected, openvr_data::Process, guess);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Compositor_ChaperoneBoundsShown, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Compositor_ChaperoneBoundsHidden, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Compositor_DisplayDisconnected, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Compositor_DisplayReconnected, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Compositor_HDCPError, openvr_data::HDCPError, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Compositor_ApplicationNotResponding, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Compositor_ApplicationResumed, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Compositor_OutOfVideoMemory, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Compositor_DisplayModeNotSupported, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Compositor_StageOverrideReady, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Compositor_RequestDisconnectReconnect, openvr_data::Unknown, none);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_TrackedCamera_StartVideoStream, openvr_data::None, guess); // trackedDeviceIndex probably indicates source
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_TrackedCamera_StopVideoStream, openvr_data::None, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_TrackedCamera_PauseVideoStream, openvr_data::None, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_TrackedCamera_ResumeVideoStream, openvr_data::None, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_TrackedCamera_EditingSurface, openvr_data::EditingCameraSurface, guess);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_PerformanceTest_EnableCapture, openvr_data::None, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_PerformanceTest_DisableCapture, openvr_data::None, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_PerformanceTest_FidelityLevel, openvr_data::PerformanceTest, guess); // fidelity is the only member of the struct
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_MessageOverlay_Closed, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_MessageOverlayCloseRequested, openvr_data::Unknown, none);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Input_HapticVibration, openvr_data::HapticVibration, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Input_BindingLoadFailed, openvr_data::InputBindingLoad, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Input_BindingLoadSuccessful, openvr_data::InputBindingLoad, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Input_ActionManifestReloaded, openvr_data::None, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Input_ActionManifestLoadFailed, openvr_data::InputActionManifestLoad, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Input_ProgressUpdate, openvr_data::ProgressUpdate, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Input_TrackerActivated, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Input_BindingsUpdated, openvr_data::Unknown, none);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Input_BindingSubscriptionChanged, openvr_data::Unknown, none);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_SpatialAnchors_PoseUpdated, openvr_data::SpatialAnchor, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_SpatialAnchors_DescriptorUpdated, openvr_data::SpatialAnchor, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_SpatialAnchors_RequestPoseUpdate, openvr_data::SpatialAnchor, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_SpatialAnchors_RequestDescriptorUpdate, openvr_data::SpatialAnchor, header);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_SystemReport_Started, openvr_data::Unknown, none);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Monitor_ShowHeadsetView, openvr_data::Process, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Monitor_HideHeadsetView, openvr_data::Process, header);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Audio_SetSpeakersVolume, openvr_data::AudioVolumeControl, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Audio_SetSpeakersMute, openvr_data::AudioMuteControl, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Audio_SetMicrophoneVolume, openvr_data::AudioVolumeControl, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_Audio_SetMicrophoneMute, openvr_data::AudioMuteControl, guess);
+}
+
+void OpenVREventHandler::register_event_signal(uint32_t p_event_id, openvr_data::OpenVREventDataType p_type, String p_signal_name) {
+	Dictionary eventAgeSeconds;
+	eventAgeSeconds["name"] = "eventAgeSeconds";
+	eventAgeSeconds["type"] = Variant::INT;
+	Dictionary trackedDeviceIndex;
+	trackedDeviceIndex["name"] = "trackedDeviceIndex";
+	trackedDeviceIndex["type"] = Variant::INT;
+	Dictionary data;
+	data["name"] = "data";
+	data["type"] = Variant::DICTIONARY;
+
+	Array args;
+	args.push_back(eventAgeSeconds);
+	args.push_back(trackedDeviceIndex);
+	args.push_back(data);
+
+	this->add_user_signal(p_signal_name, args);
+	openvr_data::register_event_signal(p_event_id, p_type, p_signal_name);
+}
+
+OpenVREventHandler::OpenVREventHandler() {
+	ovr = openvr_data::retain_singleton();
+	ovr->set_vrevent_handler(this);
+}
+
+OpenVREventHandler::~OpenVREventHandler() {
+	ovr->remove_vrevent_handler(this);
+	ovr->release();
+}

--- a/src/open_vr/openvr_event_handler.h
+++ b/src/open_vr/openvr_event_handler.h
@@ -1,0 +1,27 @@
+#ifndef OPENVR_EVENT_HANDLER_H
+#define OPENVR_EVENT_HANDLER_H
+
+#include <godot_cpp/classes/node.hpp>
+
+#include "openvr_data.h"
+
+namespace godot {
+class OpenVREventHandler : public Node {
+	GDCLASS(OpenVREventHandler, Node)
+
+public:
+	// Register an event type which exists in a newer version of OpenVR.
+	void register_event_signal(uint32_t p_event_id, openvr_data::OpenVREventDataType p_type, String p_signal_name);
+
+private:
+	openvr_data *ovr;
+
+protected:
+	static void _bind_methods();
+
+	OpenVREventHandler();
+	~OpenVREventHandler();
+};
+} // namespace godot
+
+#endif /* OPENVR_EVENT_HANDLER_H */

--- a/src/open_vr/openvr_event_signals.h
+++ b/src/open_vr/openvr_event_signals.h
@@ -1,0 +1,18 @@
+#ifndef OPENVR_EVENT_SIGNALS_H
+#define OPENVR_EVENT_SIGNALS_H
+
+// This macro is used to define signals for each VREvent to make it impossible for the list of signals to get out of sync with
+// the events. The name of the signal is automatically derived from the EVREventType. This would normally be impossible since
+// there is no way to introspect the name of enum members. While IVRSystem provides GetEventTypeNameFromEnum, this would
+// require connecting to OpenVR before creating our signals which makes the experience in the editor less than ideal.
+#define VREVENT_SIGNAL(vrevent_id, vrevent_type, source)                             \
+	{                                                                                \
+		String name = String(#vrevent_id).trim_prefix("vr::EVREventType::VREvent_"); \
+		ADD_SIGNAL(MethodInfo(name,                                                  \
+				PropertyInfo(Variant::INT, "eventAgeSeconds"),                       \
+				PropertyInfo(Variant::OBJECT, "positionalTracker"),                  \
+				PropertyInfo(Variant::DICTIONARY, "data")));                         \
+		openvr_data::register_event_signal(vrevent_id, vrevent_type, name);          \
+	}
+
+#endif /* OPENVR_EVENT_SIGNALS_H */

--- a/src/open_vr/openvr_overlay_container.cpp
+++ b/src/open_vr/openvr_overlay_container.cpp
@@ -8,6 +8,8 @@
 #include <godot_cpp/core/class_db.hpp>
 #include <godot_cpp/variant/utility_functions.hpp>
 
+#include "openvr_event_signals.h"
+
 using namespace godot;
 
 void OpenVROverlayContainer::_bind_methods() {
@@ -60,6 +62,33 @@ void OpenVROverlayContainer::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "multi_cursor"), "set_flag", "get_flag", vr::VROverlayFlags_MultiCursor);
 
 	ClassDB::bind_method(D_METHOD("on_frame_post_draw"), &OpenVROverlayContainer::on_frame_post_draw);
+
+	// Events
+	// See openvr_event_handler.cpp for an explanation of this macro.
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_MouseMove, openvr_data::Mouse, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_MouseButtonDown, openvr_data::Mouse, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_MouseButtonUp, openvr_data::Mouse, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_FocusEnter, openvr_data::Overlay, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_FocusLeave, openvr_data::Overlay, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ScrollDiscrete, openvr_data::Scroll, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_TouchPadMove, openvr_data::Mouse, header);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ScrollSmooth, openvr_data::Scroll, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_LockMousePosition, openvr_data::Mouse, header);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_UnlockMousePosition, openvr_data::Mouse, header);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_OverlayShown, openvr_data::None, tested);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_OverlayHidden, openvr_data::None, tested);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ImageLoaded, openvr_data::Unknown, none);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_OverlayGamepadFocusGained, openvr_data::None, guess);
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_OverlayGamepadFocusLost, openvr_data::None, guess);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_ImageFailed, openvr_data::Unknown, none);
+
+	VREVENT_SIGNAL(vr::EVREventType::VREvent_OverlayClosed, openvr_data::Overlay, guess);
 }
 
 OpenVROverlayContainer::OpenVROverlayContainer() {
@@ -98,7 +127,7 @@ void OpenVROverlayContainer::_notification(int p_what) {
 		}
 
 		// Tie our new overlay to this container so that events can make it back here later.
-		overlay_id = ovr->add_overlay(overlay, ObjectID(get_instance_id()));
+		overlay_id = ovr->add_overlay(overlay, this);
 
 		// We have no way of knowing when our SubViewports' textures are actually updated. Connect to the
 		// frame_post_draw signal so we can update the overlay every frame just in case.

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -16,6 +16,7 @@
 
 #include "OpenVRRenderModel.h"
 #include "OpenVRSkeleton.h"
+#include "openvr_event_handler.h"
 #include "openvr_overlay_container.h"
 #include "xr_interface_openvr.h"
 
@@ -34,6 +35,9 @@ void initialize_gdextension_types(ModuleInitializationLevel p_level) {
 	ClassDB::register_class<OpenVROverlayContainer>();
 	ClassDB::register_class<OpenVRRenderModel>();
 	ClassDB::register_class<OpenVRSkeleton>();
+
+	// Virtual classes
+	ClassDB::register_class<OpenVREventHandler>(true);
 }
 
 extern "C" {


### PR DESCRIPTION
Does what it says on the tin. Global events are exposed on the OpenVRInterface autoload, since it was already present and isn't likely to go away anytime soon. Overlay events are exposed on the overlay containers.

I updated OpenVR to 2.5.1 to pick up all the newest events.

There are a couple design choices in here I should elaborate on:
- The macro for defining the signals. I'm not happy about using one, but the amount of code and potential for human error was too high otherwise. There are an enormous number of events to expose, and for them to be visible in the editor instead of just at runtime we can't make use of any of the name lookup functionality provided by libopenvr. I thought that this macro was acceptable because it's used in the same context as all of godot-cpp's method binding macros, so the concept will be somewhat familiar.
- The macro has a weird extra argument. The last argument does absolutely nothing, it is there to enforce that there is some sort of provenance for the type information of each event. Valve documents almost none of them, and some information is only found in Github issues. I wanted to preserve as much context as possible. This argument could be removed in favor of a comment on every line if desired.
- Event signals do not follow Godot's style guidelines. Due to the lack of official documentation, I wanted to make it possible to look at code using this library and search for the events in other languages without worrying about un-transforming them back into Valve's "style". Additionally, because said style is "whoever typed it in did whatever they wanted", there's no good way to consistently generate a Godot-style signal name and it would have to be done manually for each one.
- I added a mechanism for registering additional events that we don't yet know about as user signals. This would allow someone to make use of a newly-released event by updating libopenvr even if we have not yet cut a release that adds the new constants. If this seems too weird, it can be removed.

I added a small event log to the HUD in the demo to show off this functionality and as a minimal form of test.

I also had to disable GCC variable tracking on the event handler class because of the sheer number of structs that are created to register all of the signals.