### PR TITLE
Fix pose actions

### DIFF
--- a/demo/addons/godot-openvr/actions/bindings_index_controller.json
+++ b/demo/addons/godot-openvr/actions/bindings_index_controller.json
@@ -15,19 +15,19 @@
 			],
 			"poses" : [
 				{
-					"output" : "/actions/godot/in/grip_pose",
+					"output" : "/actions/godot/in/grip",
 					"path" : "/user/hand/left/pose/handgrip"
 				},
 				{
-					"output" : "/actions/godot/in/grip_pose",
+					"output" : "/actions/godot/in/grip",
 					"path" : "/user/hand/right/pose/handgrip"
 				},
 				{
-					"output" : "/actions/godot/in/aim_pose",
+					"output" : "/actions/godot/in/aim",
 					"path" : "/user/hand/left/pose/tip"
 				},
 				{
-					"output" : "/actions/godot/in/aim_pose",
+					"output" : "/actions/godot/in/aim",
 					"path" : "/user/hand/right/pose/tip"
 				}
 			],

--- a/demo/addons/godot-openvr/actions/bindings_oculus_touch.json
+++ b/demo/addons/godot-openvr/actions/bindings_oculus_touch.json
@@ -15,11 +15,11 @@
 			],
 			"poses" : [
 				{
-					"output" : "/actions/godot/in/aim_pose",
+					"output" : "/actions/godot/in/aim",
 					"path" : "/user/hand/left/pose/tip"
 				},
 				{
-					"output" : "/actions/godot/in/aim_pose",
+					"output" : "/actions/godot/in/aim",
 					"path" : "/user/hand/right/pose/tip"
 				},
 				{
@@ -27,11 +27,11 @@
 					"path" : "/user/hand/left/pose/openxr_aim"
 				},
 				{
-					"output" : "/actions/godot/in/grip_pose",
+					"output" : "/actions/godot/in/grip",
 					"path" : "/user/hand/left/pose/handgrip"
 				},
 				{
-					"output" : "/actions/godot/in/grip_pose",
+					"output" : "/actions/godot/in/grip",
 					"path" : "/user/hand/right/pose/handgrip"
 				}
 			],

--- a/demo/addons/godot-openvr/actions/bindings_vive_controller.json
+++ b/demo/addons/godot-openvr/actions/bindings_vive_controller.json
@@ -15,19 +15,19 @@
 			],
 			"poses" : [
 				{
-					"output" : "/actions/godot/in/grip_pose",
+					"output" : "/actions/godot/in/grip",
 					"path" : "/user/hand/left/pose/handgrip"
 				},
 				{
-					"output" : "/actions/godot/in/grip_pose",
+					"output" : "/actions/godot/in/grip",
 					"path" : "/user/hand/right/pose/handgrip"
 				},
 				{
-					"output" : "/actions/godot/in/aim_pose",
+					"output" : "/actions/godot/in/aim",
 					"path" : "/user/hand/left/pose/tip"
 				},
 				{
-					"output" : "/actions/godot/in/aim_pose",
+					"output" : "/actions/godot/in/aim",
 					"path" : "/user/hand/right/pose/tip"
 				}
 			],

--- a/src/open_vr/openvr_data.cpp
+++ b/src/open_vr/openvr_data.cpp
@@ -1138,6 +1138,12 @@ void openvr_data::process_device_actions(tracked_device *p_device, uint64_t p_ms
 
 	// Check our action based poses
 	for (auto pose : poses) {
+		// The godot actionset is special, we trim off the action set prefix so the poses will be mapped to the standard names Godot expects from an XRInterface.
+		// This still requires the application to include the /actions/godot actionset in its manifest to receive these poses.
+		// It's recommended that this actionset by set to `"usage": "hidden"` so the user can't unmap it in the bindings UI.
+		// Other actionset names won't be affected by this trim and are used unmodified.
+		String pose_name = pose.name.trim_prefix("/actions/godot/in/");
+
 		if (pose.handle != vr::k_ulInvalidActionHandle) {
 			// TODO change vr::TrackingUniverseStanding to correct value
 			vr::InputPoseActionData_t data;
@@ -1145,19 +1151,19 @@ void openvr_data::process_device_actions(tracked_device *p_device, uint64_t p_ms
 			if (err != vr::VRInputError_None) {
 				// No new status
 			} else if (!data.bActive) {
-				p_device->tracker->invalidate_pose(pose.name);
+				p_device->tracker->invalidate_pose(pose_name);
 			} else if (!data.pose.bPoseIsValid) {
-				p_device->tracker->invalidate_pose(pose.name);
+				p_device->tracker->invalidate_pose(pose_name);
 			} else {
 				XRPose::TrackingConfidence confidence = confidence_from_tracking_result(data.pose.eTrackingResult);
 				Transform3D transform = transform_from_matrix(&data.pose.mDeviceToAbsoluteTracking, 1.0);
 				Vector3 linear_velocity(data.pose.vVelocity.v[0], data.pose.vVelocity.v[1], data.pose.vVelocity.v[2]);
 				Vector3 angular_velocity(data.pose.vAngularVelocity.v[0], data.pose.vAngularVelocity.v[1], data.pose.vAngularVelocity.v[2]);
 
-				p_device->tracker->set_pose(pose.name, transform, linear_velocity, angular_velocity, confidence);
+				p_device->tracker->set_pose(pose_name, transform, linear_velocity, angular_velocity, confidence);
 			}
 		} else {
-			p_device->tracker->invalidate_pose(pose.name);
+			p_device->tracker->invalidate_pose(pose_name);
 		}
 	}
 


### PR DESCRIPTION
When I ported actionsets over to being generated from the manifest, I neglected to hook the poses back up to the default ones that godot expects from XRInterfaces. I've settled on doing this by treating the `/actions/godot` set as special and stripping the path prefix from poses. This way you can still map them in custom actionsets if you want, and use them by providing the full path name as a custom pose for your XRNode3D.

If this approach seems reasonable I would be inclined to do the same thing for other actions under the godot namespace so buttons can be mapped to the simple x/y/a/b/etc names within the input system if so desired.

This doesn't fix the skeleton poses yet since they are a different type in the manifest and we currently ignore them entirely.

The intended way to use this would be to ship an action manifest for your app that includes both the default `/actions/godot` set to capture poses for the engine to consume, which makes XRNode3D Just Work™, and then also have a separate actionset named after your app which is intended for users to customize in the SteamVR bindings UI. The godot set would be marked hidden to prevent users from breaking poses.