### PR TITLE
Expose more information

### DIFF
--- a/src/xr_interface_openvr.cpp
+++ b/src/xr_interface_openvr.cpp
@@ -2,7 +2,6 @@
 // Our main XRInterface code for our OpenVR GDExtension module
 
 #include "xr_interface_openvr.h"
-#include "openvr_mingw.hpp"
 
 #include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/rendering_device.hpp>

--- a/src/xr_interface_openvr.cpp
+++ b/src/xr_interface_openvr.cpp
@@ -2,6 +2,7 @@
 // Our main XRInterface code for our OpenVR GDExtension module
 
 #include "xr_interface_openvr.h"
+#include "openvr_mingw.hpp"
 
 #include <godot_cpp/classes/os.hpp>
 #include <godot_cpp/classes/rendering_device.hpp>
@@ -26,6 +27,7 @@ void XRInterfaceOpenVR::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_action_set_active"), &XRInterfaceOpenVR::is_action_set_active);
 
 	ClassDB::bind_method(D_METHOD("is_dashboard_visible"), &XRInterfaceOpenVR::is_dashboard_visible);
+	ClassDB::bind_method(D_METHOD("get_application_key"), &XRInterfaceOpenVR::get_application_key);
 
 	ClassDB::bind_method(D_METHOD("play_area_available"), &XRInterfaceOpenVR::play_area_available);
 	ClassDB::bind_method(D_METHOD("get_play_area"), &XRInterfaceOpenVR::get_play_area);
@@ -101,6 +103,23 @@ bool XRInterfaceOpenVR::is_dashboard_visible() {
 	}
 
 	return vr::VROverlay()->IsDashboardVisible();
+}
+
+String XRInterfaceOpenVR::get_application_key() {
+	if (ovr == nullptr) {
+		return "";
+	}
+
+	uint32_t pid = OS::get_singleton()->get_process_id();
+
+	char key[vr::k_unMaxApplicationKeyLength];
+	vr::EVRApplicationError error = vr::VRApplications()->GetApplicationKeyByProcessId(
+			pid, key, vr::k_unMaxApplicationKeyLength);
+	if (error != vr::VRApplicationError_None) {
+		return "";
+	}
+
+	return key;
 }
 
 bool XRInterfaceOpenVR::play_area_available() const {

--- a/src/xr_interface_openvr.cpp
+++ b/src/xr_interface_openvr.cpp
@@ -34,6 +34,8 @@ void XRInterfaceOpenVR::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_render_model_names"), &XRInterfaceOpenVR::get_render_model_names);
 	ClassDB::bind_method(D_METHOD("load_render_model", "model_name"), &XRInterfaceOpenVR::load_render_model);
 	ClassDB::bind_method(D_METHOD("load_render_model_components", "model_name"), &XRInterfaceOpenVR::load_render_model_components);
+
+	ClassDB::bind_method(D_METHOD("get_raw_projection_matrix", "eye"), &XRInterfaceOpenVR::get_raw_projection_matrix);
 }
 
 int XRInterfaceOpenVR::get_application_type() const {
@@ -208,6 +210,19 @@ Array XRInterfaceOpenVR::load_render_model_components(String p_model_name) {
 	}
 
 	return components;
+}
+
+////////////////////////////////////////////////////////////////
+// This returns the underlying projection matrix reported by OpenVR.
+// The elements of the array are left, right, top, bottom.
+PackedFloat32Array XRInterfaceOpenVR::get_raw_projection_matrix(uint32_t p_view) {
+	PackedFloat32Array arr;
+	arr.resize(4);
+
+	ovr->hmd->GetProjectionRaw(
+			p_view == 0 ? vr::Eye_Left : vr::Eye_Right, &arr[0], &arr[1], &arr[2], &arr[3]);
+
+	return arr;
 }
 
 ////////////////////////////////////////////////////////////////

--- a/src/xr_interface_openvr.cpp
+++ b/src/xr_interface_openvr.cpp
@@ -25,6 +25,8 @@ void XRInterfaceOpenVR::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_action_set_active"), &XRInterfaceOpenVR::set_action_set_active);
 	ClassDB::bind_method(D_METHOD("is_action_set_active"), &XRInterfaceOpenVR::is_action_set_active);
 
+	ClassDB::bind_method(D_METHOD("is_dashboard_visible"), &XRInterfaceOpenVR::is_dashboard_visible);
+
 	ClassDB::bind_method(D_METHOD("play_area_available"), &XRInterfaceOpenVR::play_area_available);
 	ClassDB::bind_method(D_METHOD("get_play_area"), &XRInterfaceOpenVR::get_play_area);
 
@@ -91,6 +93,14 @@ bool XRInterfaceOpenVR::is_action_set_active(const String p_action_set) const {
 	}
 
 	return ovr->is_action_set_active(p_action_set);
+}
+
+bool XRInterfaceOpenVR::is_dashboard_visible() {
+	if (ovr == nullptr) {
+		return false;
+	}
+
+	return vr::VROverlay()->IsDashboardVisible();
 }
 
 bool XRInterfaceOpenVR::play_area_available() const {

--- a/src/xr_interface_openvr.h
+++ b/src/xr_interface_openvr.h
@@ -41,6 +41,8 @@ public:
 	void set_action_set_active(const String p_action_set, const bool p_is_active);
 	bool is_action_set_active(const String p_action_set) const;
 
+	bool is_dashboard_visible();
+
 	bool play_area_available() const;
 	PackedVector3Array get_play_area() const;
 

--- a/src/xr_interface_openvr.h
+++ b/src/xr_interface_openvr.h
@@ -72,6 +72,8 @@ public:
 	Ref<ArrayMesh> load_render_model(String p_model_name);
 	Array load_render_model_components(String p_model_name);
 
+	PackedFloat32Array get_raw_projection_matrix(uint32_t p_view);
+
 	XRInterfaceOpenVR();
 	~XRInterfaceOpenVR();
 };

--- a/src/xr_interface_openvr.h
+++ b/src/xr_interface_openvr.h
@@ -42,6 +42,7 @@ public:
 	bool is_action_set_active(const String p_action_set) const;
 
 	bool is_dashboard_visible();
+	String get_application_key();
 
 	bool play_area_available() const;
 	PackedVector3Array get_play_area() const;


### PR DESCRIPTION
Expose a few more bits of information:

- `is_dashboard_visible` returns whether the SteamVR dashboard is currently visible, supplements the VREvent by allowing checking the state at startup instead of waiting for it to change once.
- `get_application_key` returns the steam application key for this game.
- `get_raw_projection_matrix` returns the matrix for the given eye. This one is pretty obscure, I needed it to find the center of each eye at a given distance. If there's a better way to do this with info that Godot already has, I'd be happy to drop this.