### PR TITLE
Avoid spurious digital inputs with inactive sets

### DIFF
--- a/src/open_vr/openvr_data.cpp
+++ b/src/open_vr/openvr_data.cpp
@@ -1136,8 +1136,9 @@ void openvr_data::process_device_actions(tracked_device *p_device, uint64_t p_ms
 					vr::InputDigitalActionData_t action_data;
 					vr::EVRInputError err = vr::VRInput()->GetDigitalActionData(input.handle, &action_data, sizeof(action_data), p_device->source_handle);
 					if (err == vr::VRInputError_None) {
-						bool pressed = action_data.bActive && action_data.bState;
-						p_device->tracker->set_input(input.name, pressed);
+						if (action_data.bActive) {
+							p_device->tracker->set_input(input.name, action_data.bState);
+						}
 					}
 				} break;
 				case IT_FLOAT: {


### PR DESCRIPTION
This is a weird one.

For reasons I haven't yet determined, we occasionally get `bActive == false` back from openvr for a few frames when overlays become invisible (I think?), but _only if the overlay intersects the laser when hidden_. This doesn't make any sense at all which makes me suspect we have a bug somewhere else, but I can't find it. I monitored the state we send into openvr and we're never accidentally deactivating sets that I can see.

In any case, this situation causes us to clear and immediately (a frame later) re-set the input on the tracker, making it look like the user double-pressed the button. Not setting the input at all when the action is inactive matches the logic for the other types of inputs and fixes the double-press.

I will continue to investigate _why_ this is sent. (cc @BastiaanOlij in case you remember anything surrounding this while originally adding the action set support.)